### PR TITLE
Add output path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,26 @@ Prepare your dataset of CWT images arranged in sub‑folders for each class. The
 run the training script:
 
 ```bash
-python main.py --data-dir path/to/images_cwt_224x224_rgb --epochs 25
+python main.py \
+  --data-dir path/to/images_cwt_224x224_rgb \
+  --output-dir training_runs/run1 \
+  --epochs 25
 ```
+
+The dataset directory must follow this structure:
+
+```
+images_cwt_224x224_rgb/
+├── class_a/
+│   ├── img1.png
+│   └── ...
+├── class_b/
+│   └── ...
+└── class_n/
+    └── ...
+```
+
+The trained model is saved to `<output-dir>/model.pth`.
 
 The script will train a Swin Transformer on the dataset and evaluate it on a
 held‑out test set.

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import torch
 from src.models.swin import get_swin_tiny_partial_finetune
 from src.train import create_dataloaders, train_model
@@ -11,15 +12,35 @@ def parse_args():
     parser.add_argument('--epochs', type=int, default=10, help='Number of epochs')
     parser.add_argument('--batch-size', type=int, default=32, help='Batch size')
     parser.add_argument('--lr', type=float, default=1e-4, help='Learning rate')
+    parser.add_argument(
+        '--output-dir',
+        type=str,
+        default='outputs',
+        help='Directory to store training artifacts',
+    )
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    train_loader, val_loader, test_loader = create_dataloaders(args.data_dir, batch_size=args.batch_size)
+    train_loader, val_loader, test_loader = create_dataloaders(
+        args.data_dir, batch_size=args.batch_size
+    )
     model = get_swin_tiny_partial_finetune()
-    model = train_model(model, train_loader, val_loader, device, num_epochs=args.epochs, lr=args.lr)
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    model_path = os.path.join(args.output_dir, 'model.pth')
+
+    model = train_model(
+        model,
+        train_loader,
+        val_loader,
+        device,
+        num_epochs=args.epochs,
+        lr=args.lr,
+        save_path=model_path,
+    )
     evaluate_model(model, test_loader, device, class_names=list(train_loader.dataset.dataset.class_to_idx.keys()))
 
 

--- a/src/train.py
+++ b/src/train.py
@@ -29,8 +29,15 @@ def create_dataloaders(root_dir: str, batch_size: int = 32,
     return train_loader, val_loader, test_loader
 
 
-def train_model(model: torch.nn.Module, train_loader: DataLoader, val_loader: DataLoader,
-                device: torch.device, num_epochs: int = 10, lr: float = 1e-4) -> torch.nn.Module:
+def train_model(
+    model: torch.nn.Module,
+    train_loader: DataLoader,
+    val_loader: DataLoader,
+    device: torch.device,
+    num_epochs: int = 10,
+    lr: float = 1e-4,
+    save_path: str | None = None,
+) -> torch.nn.Module:
     model.to(device)
     criterion = nn.CrossEntropyLoss()
     optimizer = optim.AdamW(filter(lambda p: p.requires_grad, model.parameters()), lr=lr)
@@ -64,4 +71,9 @@ def train_model(model: torch.nn.Module, train_loader: DataLoader, val_loader: Da
                 val_total += labels.size(0)
         val_acc = 100.0 * val_correct / val_total
         print(f"Validation — Acc={val_acc:.2f}%")
+
+    if save_path:
+        os.makedirs(os.path.dirname(save_path), exist_ok=True)
+        torch.save(model.state_dict(), save_path)
+
     return model


### PR DESCRIPTION
## Summary
- allow specifying an output directory on the CLI and save a model checkpoint there
- document the dataset folder layout and new argument in README

## Testing
- `python -m py_compile main.py src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688635498430832f9a4fd58da7dd1d5c