### PR TITLE
Add dataset generation CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ pip install -r requirements.txt
 
 ## Usage
 
+### Generate the CWT image dataset
+
+If you start from the raw *hawk* measurements you can create the image dataset
+using the CLI provided in `scripts/generate_dataset.py`:
+
+```bash
+python scripts/generate_dataset.py /path/to/hawk_data images_cwt_224x224_rgb
+```
+
+### Train the model
+
 Prepare your dataset of CWT images arranged in sub‑folders for each class. Then
 run the training script:
 
@@ -39,3 +50,4 @@ The trained model is saved to `<output-dir>/model.pth`.
 
 The script will train a Swin Transformer on the dataset and evaluate it on a
 held‑out test set.
+

--- a/scripts/generate_dataset.py
+++ b/scripts/generate_dataset.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""CLI to generate CWT image dataset from hawk-data tests."""
+import argparse
+import os
+from typing import Dict, List
+
+import numpy as np
+
+try:
+    from hawk import FST  # type: ignore
+except Exception as e:  # pragma: no cover - optional dependency
+    FST = None  # type: ignore
+
+from src.utils.cwt import generate_cwt_image, save_images
+
+TESTS_PER_CLASS: Dict[str, List[str]] = {
+    "HS": [
+        "HS_WN/01",
+        "HS_WN/02",
+        "HS_WN/03",
+        "HS_WN/04",
+        "HS_WN/05",
+    ],
+    "DS_CTE": [
+        "DS_WN/01",
+        "DS_WN/02",
+        "DS_WN/03",
+        "DS_WN/19",
+        "DS_WN/20",
+        "DS_WN/21",
+        "DS_WN/64",
+        "DS_WN/65",
+        "DS_WN/66",
+    ],
+    "DS_RLE": [
+        "DS_WN/04",
+        "DS_WN/05",
+        "DS_WN/06",
+        "DS_WN/22",
+        "DS_WN/23",
+        "DS_WN/24",
+        "DS_WN/67",
+        "DS_WN/68",
+        "DS_WN/69",
+    ],
+    "DS_TLE": [
+        "DS_WN/07",
+        "DS_WN/08",
+        "DS_WN/09",
+        "DS_WN/25",
+        "DS_WN/26",
+        "DS_WN/27",
+        "DS_WN/70",
+        "DS_WN/71",
+        "DS_WN/72",
+    ],
+}
+
+
+def extract_signal(group) -> np.ndarray:
+    """Return stacked mean strain for the 10 FBG sensors."""
+    signals = []
+    for i in range(1, 11):
+        sensor = f"SW_FB{i}"
+        strain = group[sensor]["strain"][:]
+        signal_mean = strain.mean(axis=1)
+        signals.append(signal_mean)
+    return np.array(signals)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate CWT images from hawk-data")
+    parser.add_argument("data_dir", help="Path to hawk_data directory")
+    parser.add_argument("output_dir", help="Where to store generated images")
+    parser.add_argument("--width", type=int, default=224, help="Target scalogram width")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if FST is None:
+        raise RuntimeError("hawk-data package is required to generate the dataset")
+
+    data = FST(args.data_dir)
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    for clazz, tests in TESTS_PER_CLASS.items():
+        for test in tests:
+            print(f"Processing {test} ({clazz})")
+            group = data[test]
+            signals = extract_signal(group)
+            images = generate_cwt_image(signals, target_width=args.width)
+            save_images(images, args.output_dir, test, clazz)
+            print(f"  -> saved {len(images)} images")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide `scripts/generate_dataset.py` for producing CWT image datasets from raw hawk data
- document dataset creation and training usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688636ea7be8832fa789964fa7c87eaf