### PR TITLE
Add tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/tests/test_cwt.py
+++ b/tests/test_cwt.py
@@ -1,0 +1,18 @@
+import numpy as np
+from src.utils.cwt import compute_scalogram, resize_vertical_all_repeat
+
+
+def test_compute_scalogram_shape_and_range():
+    signal = np.random.randn(2048)
+    result = compute_scalogram(signal)
+    assert result.shape == (224,)
+    assert np.all(result >= 0) and np.all(result <= 1)
+
+
+def test_resize_vertical_all_repeat():
+    img = np.arange(12).reshape(3, 4)
+    resized = resize_vertical_all_repeat(img, target_height=5)
+    assert resized.shape == (5, 4)
+    # rows should repeat in order
+    assert np.array_equal(resized[0:3], img)
+    assert np.array_equal(resized[3:], img[:2])


### PR DESCRIPTION
## Summary
- add unit tests for `compute_scalogram` and `resize_vertical_all_repeat`
- run tests in GitHub Actions on push

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68863b9c7740832f8e8a59d849245ce4