### PR TITLE
Fix average loss reporting

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -58,7 +58,8 @@ def train_model(
             correct += (predicted == labels).sum().item()
             total += labels.size(0)
         train_acc = 100.0 * correct / total
-        print(f"Train — Epoch {epoch+1}: Loss={running_loss:.4f} Acc={train_acc:.2f}%")
+        avg_loss = running_loss / len(train_loader)
+        print(f"Train — Epoch {epoch+1}: Loss={avg_loss:.4f} Acc={train_acc:.2f}%")
         model.eval()
         val_correct = 0
         val_total = 0


### PR DESCRIPTION
## Summary
- calculate mean training loss per epoch in `train.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688643941d90832fbebf00440bf0fa54