### PR TITLE
Add repository-wide .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+dist/
+*.egg-info/
+
+# Pytest cache
+.pytest_cache/
+
+# Notebook files
+*.ipynb
+
+# Large dataset archives
+src/data/*.zip
+


### PR DESCRIPTION
## Summary
- avoid committing Python bytecode, build output, and `.pytest_cache`
- ignore any notebooks and dataset zip archives under `src/data`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688646b83398832faf404fa429455e66