### PR TITLE
Add CBAM attention and SwinWithAttention model

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,10 @@
+from .swin import get_swin_tiny_partial_finetune, SwinWithAttention
+from .cbam import CBAM, ChannelAttention, SpatialAttention
+
+__all__ = [
+    "get_swin_tiny_partial_finetune",
+    "SwinWithAttention",
+    "CBAM",
+    "ChannelAttention",
+    "SpatialAttention",
+]

--- a/src/models/cbam.py
+++ b/src/models/cbam.py
@@ -1,0 +1,49 @@
+import torch
+from torch import nn
+
+
+class ChannelAttention(nn.Module):
+    def __init__(self, channels: int, reduction: int = 16) -> None:
+        super().__init__()
+        mid_channels = max(1, channels // reduction)
+        self.avg_pool = nn.AdaptiveAvgPool2d(1)
+        self.max_pool = nn.AdaptiveMaxPool2d(1)
+        self.mlp = nn.Sequential(
+            nn.Conv2d(channels, mid_channels, kernel_size=1, bias=False),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(mid_channels, channels, kernel_size=1, bias=False),
+        )
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        avg_out = self.mlp(self.avg_pool(x))
+        max_out = self.mlp(self.max_pool(x))
+        attn = self.sigmoid(avg_out + max_out)
+        return x * attn
+
+
+class SpatialAttention(nn.Module):
+    def __init__(self, kernel_size: int = 7) -> None:
+        super().__init__()
+        padding = kernel_size // 2
+        self.conv = nn.Conv2d(2, 1, kernel_size=kernel_size, padding=padding, bias=False)
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        avg_out = torch.mean(x, dim=1, keepdim=True)
+        max_out, _ = torch.max(x, dim=1, keepdim=True)
+        concat = torch.cat([avg_out, max_out], dim=1)
+        attn = self.sigmoid(self.conv(concat))
+        return x * attn
+
+
+class CBAM(nn.Module):
+    def __init__(self, channels: int, reduction: int = 16, kernel_size: int = 7) -> None:
+        super().__init__()
+        self.channel_att = ChannelAttention(channels, reduction)
+        self.spatial_att = SpatialAttention(kernel_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.channel_att(x)
+        x = self.spatial_att(x)
+        return x

--- a/src/models/swin.py
+++ b/src/models/swin.py
@@ -1,4 +1,8 @@
 import timm
+import torch
+from torch import nn
+
+from .cbam import CBAM
 
 
 def get_swin_tiny_partial_finetune(num_classes: int = 4, pretrained: bool = True,
@@ -20,3 +24,28 @@ def get_swin_tiny_partial_finetune(num_classes: int = 4, pretrained: bool = True
     for param in model.head.parameters():
         param.requires_grad = True
     return model
+
+
+class SwinWithAttention(nn.Module):
+    """Swin-Tiny backbone followed by CBAM attention and a classifier."""
+
+    def __init__(self, num_classes: int = 4, pretrained: bool = True) -> None:
+        super().__init__()
+        self.backbone = timm.create_model(
+            "swin_tiny_patch4_window7_224",
+            pretrained=pretrained,
+            num_classes=0,
+            global_pool="",
+        )
+        self.cbam = CBAM(self.backbone.num_features)
+        self.pool = nn.AdaptiveAvgPool2d(1)
+        self.fc = nn.Linear(self.backbone.num_features, num_classes)
+        self.num_classes = num_classes
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.backbone.forward_features(x)
+        x = self.cbam(x)
+        x = self.pool(x)
+        x = torch.flatten(x, 1)
+        x = self.fc(x)
+        return x


### PR DESCRIPTION
## Summary
- add ChannelAttention/SpatialAttention/CBAM modules
- implement `SwinWithAttention` that attaches CBAM and classifier to a swin backbone
- export new classes from `src/models/__init__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688668e876ec832fa0ba4c615a8b290d