### PR TITLE
Improve installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,23 @@ Install the required Python packages with pip:
 pip install -r requirements.txt
 ```
 
+You can also perform an offline installation using the provided
+`setup.sh` script:
+
+```bash
+./setup.sh
+```
+
+This script installs packages from wheel files located in the `wheels/`
+directory. Make sure all the required wheels are available in this folder
+before running it.
+
+After installation, run the test suite to verify the environment:
+
+```bash
+pytest
+```
+
 ## Usage
 
 ### Generate the CWT image dataset


### PR DESCRIPTION
## Summary
- explain that `setup.sh` can be used for offline installation
- note wheel files are expected in the `wheels/` directory
- show how to run tests after installing dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6886ba087290832f82d9c7a8c938004e