### PR TITLE
Document hawk-data usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,27 @@ Install the required Python packages with pip:
 pip install -r requirements.txt
 ```
 
+### Providing `hawk-data` locally
+
+The `hawk-data` package is only needed when running
+`scripts/generate_dataset.py`.  In an offline environment you can supply this
+dependency in one of two ways:
+
+1. **Git submodule**
+
+   Add the repository as a submodule and install it in editable mode:
+
+   ```bash
+   git submodule add https://github.com/MDCHAMP/hawk-data external/hawk-data
+   pip install -e external/hawk-data
+   ```
+
+2. **Pre‑built wheel**
+
+   Build or download a wheel for `hawk-data`, place it under `wheels/` and run
+   `setup.sh`.  The script will install the wheel along with the other local
+   packages.
+
 ## Usage
 
 ### Generate the CWT image dataset

--- a/setup.sh
+++ b/setup.sh
@@ -5,3 +5,8 @@ SCRIPT_DIR=$(dirname "$0")
 pip install --no-index --find-links="$SCRIPT_DIR/wheels" \
     numpy torch torchvision timm scikit-learn matplotlib scikit-image \
     pywavelets scipy seaborn pytest
+
+# install hawk-data if a wheel is provided
+if ls "$SCRIPT_DIR"/wheels/hawk_data-*.whl > /dev/null 2>&1; then
+    pip install --no-index --find-links="$SCRIPT_DIR/wheels" hawk_data
+fi


### PR DESCRIPTION
## Summary
- clarify how to supply `hawk-data` locally
- install hawk-data wheel in `setup.sh` when available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6886ba183e9c832f94cad1b06a48579d