### PR TITLE
Handle missing denoising checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,20 @@ The trained model is saved to `<output-dir>/model.pth`.
 The script will train a Swin Transformer on the dataset and evaluate it on a
 held‑out test set.
 
+### Pretrained denoising model
+
+The dataset generation utilities rely on a small denoising network whose
+weights are **not** tracked in this repository.  To use the provided scripts you
+need the file `checkpoints/denoising_model.pth`.
+
+You can download it from the project's release page:
+
+```bash
+bash scripts/download_denoising_model.sh
+```
+
+This script downloads the checkpoint from the release and stores it in the
+`checkpoints/` directory.  If the file is missing, code that uses
+`load_denoising_model` will fall back to an untrained network and print a
+warning.
+

--- a/scripts/download_denoising_model.sh
+++ b/scripts/download_denoising_model.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Download the pretrained denoising model used by dataset generation.
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+CHECKPOINT_DIR="$SCRIPT_DIR/../checkpoints"
+mkdir -p "$CHECKPOINT_DIR"
+
+URL="https://github.com/MDCHAMP/Projet_CWT/releases/download/v1.0/denoising_model.pth"
+if [ ! -f "$CHECKPOINT_DIR/denoising_model.pth" ]; then
+    echo "Downloading denoising model from $URL"
+    curl -L "$URL" -o "$CHECKPOINT_DIR/denoising_model.pth"
+    echo "Saved to $CHECKPOINT_DIR/denoising_model.pth"
+else
+    echo "Denoising model already exists at $CHECKPOINT_DIR/denoising_model.pth"
+fi

--- a/src/models/denoising_model.py
+++ b/src/models/denoising_model.py
@@ -22,7 +22,13 @@ class SimpleDenoiser(nn.Module):
 
 
 def load_denoising_model(checkpoint_path: str = "checkpoints/denoising_model.pth") -> nn.Module:
-    """Load and return the pretrained denoising model."""
+    """Load and return the pretrained denoising model if available.
+
+    If the checkpoint is missing an untrained :class:`SimpleDenoiser` is returned
+    and a warning is printed. This keeps the rest of the pipeline usable even
+    without the pretrained weights.
+    """
+
     model = SimpleDenoiser()
     if os.path.exists(checkpoint_path):
         state = torch.load(checkpoint_path, map_location="cpu")
@@ -30,5 +36,8 @@ def load_denoising_model(checkpoint_path: str = "checkpoints/denoising_model.pth
             state = state["state_dict"]
         model.load_state_dict(state)
     else:
-        raise FileNotFoundError(f"Checkpoint not found: {checkpoint_path}")
+        print(
+            f"Warning: {checkpoint_path} not found. Using an untrained SimpleDenoiser."
+            " See the README for instructions on downloading the pretrained model."
+        )
     return model


### PR DESCRIPTION
## Summary
- avoid a crash when the denoising checkpoint is absent
- add a helper script to download the pretrained model
- document how to obtain the checkpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6886ba1d4640832fbda0ec9fd5c509cc